### PR TITLE
add set_multicast_ttl_v4 and set_multicast_hops_v6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```no_run
 //! use std::net::{Ipv4Addr, SocketAddrV4};
 //! use socket2::{Domain, SockAddr};
 //! use socket_pktinfo::PktInfoUdpSocket;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -96,6 +96,10 @@ impl PktInfoUdpSocket {
         self.socket.set_multicast_loop_v4(loop_v4)
     }
 
+    pub fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+        self.socket.set_multicast_ttl_v4(ttl)
+    }
+
     pub fn join_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.socket.join_multicast_v6(addr, interface)
     }
@@ -106,6 +110,10 @@ impl PktInfoUdpSocket {
 
     pub fn set_multicast_loop_v6(&self, loop_v6: bool) -> io::Result<()> {
         self.socket.set_multicast_loop_v6(loop_v6)
+    }
+
+    pub fn set_multicast_hops_v6(&self, hops: u32) -> io::Result<()> {
+        self.socket.set_multicast_hops_v6(hops)
     }
 
     pub fn set_nonblocking(&self, reuse: bool) -> io::Result<()> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -144,6 +144,10 @@ impl PktInfoUdpSocket {
         self.socket.set_multicast_loop_v4(loop_v4)
     }
 
+    pub fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+        self.socket.set_multicast_ttl_v4(ttl)
+    }
+
     pub fn join_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.socket.join_multicast_v6(addr, interface)
     }
@@ -154,6 +158,10 @@ impl PktInfoUdpSocket {
 
     pub fn set_multicast_loop_v6(&self, loop_v6: bool) -> io::Result<()> {
         self.socket.set_multicast_loop_v6(loop_v6)
+    }
+
+    pub fn set_multicast_hops_v6(&self, hops: u32) -> io::Result<()> {
+        self.socket.set_multicast_hops_v6(hops)
     }
 
     pub fn set_nonblocking(&self, reuse: bool) -> io::Result<()> {

--- a/tests/ipv4_test.rs
+++ b/tests/ipv4_test.rs
@@ -44,6 +44,7 @@ fn ipv4_test() -> io::Result<()> {
     socket.set_multicast_if_v4(&local_ip)?;
     socket.join_multicast_v4(&multicast_addr, &local_ip)?;
     socket.set_multicast_loop_v4(true)?;
+    socket.set_multicast_ttl_v4(255)?;
     socket.bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port).into())?;
 
     {

--- a/tests/ipv6_test.rs
+++ b/tests/ipv6_test.rs
@@ -2,7 +2,7 @@ use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use socket_pktinfo::PktInfoUdpSocket;
 use std::io;
-use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, IpAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::str::FromStr;
 
 #[test]

--- a/tests/ipv6_test.rs
+++ b/tests/ipv6_test.rs
@@ -2,7 +2,7 @@ use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use socket_pktinfo::PktInfoUdpSocket;
 use std::io;
-use std::net::{Ipv6Addr, SocketAddr};
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, IpAddr};
 use std::str::FromStr;
 
 #[test]
@@ -31,14 +31,18 @@ fn ipv6_test() -> io::Result<()> {
 
     let port = 8000;
     let multicast_addr = Ipv6Addr::from_str("ff12::1").unwrap();
-    let local_addr: SockAddr = SocketAddr::new(local_ip, port).into();
+    let IpAddr::V6(local_ipv6) = local_ip else {
+        panic!("Expected IPv6");
+    };
+    let local_addr: SockAddr = SocketAddrV6::new(local_ipv6, port, 0, interface.index).into();
     let multicast_socket_addr: SockAddr = SocketAddr::new(multicast_addr.into(), port).into();
 
     let mut buf = [0; 8972];
     let socket = PktInfoUdpSocket::new(Domain::IPV6)?;
     socket.set_reuse_address(true)?;
-    socket.join_multicast_v6(&multicast_addr, 0)?;
+    socket.join_multicast_v6(&multicast_addr, interface.index)?;
     socket.set_multicast_loop_v6(true)?;
+    socket.set_multicast_hops_v6(255)?;
     socket.bind(&local_addr)?;
 
     {


### PR DESCRIPTION
Adding two missing functions that are already supported in the underlying `socket2` lib, so that we can call them directly from this library.