### PR TITLE
bugfix: recvmsg control buffer size is wrong for IPv6 for unix

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -136,8 +136,14 @@ impl PktInfoUdpSocket {
         let mut addr_src: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::uninit();
         let mut msg_iov = IoSliceMut::new(buf);
         let mut cmsg = {
-            let space = unsafe {
-                libc::CMSG_SPACE(mem::size_of::<libc::in_pktinfo>() as libc::c_uint) as usize
+            let space = if self.domain == Domain::IPV4 {
+                unsafe {
+                    libc::CMSG_SPACE(mem::size_of::<libc::in_pktinfo>() as libc::c_uint) as usize
+                }
+            } else {
+                unsafe {
+                    libc::CMSG_SPACE(mem::size_of::<libc::in6_pktinfo>() as libc::c_uint) as usize
+                }
             };
             Vec::<u8>::with_capacity(space)
         };

--- a/tests/ipv6_test.rs
+++ b/tests/ipv6_test.rs
@@ -70,6 +70,7 @@ fn ipv6_test() -> io::Result<()> {
         "Multicast packet received on interface index {} from src {} with destination ip {}",
         info.if_index, info.addr_src, info.addr_dst,
     );
+    assert!(info.if_index != 0);
 
     Ok(())
 }


### PR DESCRIPTION
I found that the `recvmsg` control buffer size is always set to IPv4 size (`in_pktinfo`) which is wrong for IPv6.  This caused `if_index` is 0 in testing. I also noticed the `addr_dst` was not complete due to the short buffer size.
