### PR TITLE
feat: add new wrapper methods for PktInfoUdpSocket

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -88,6 +88,11 @@ impl PktInfoUdpSocket {
         self.socket.join_multicast_v4(addr, interface)
     }
 
+    /// Drop membership in a multicast group for IPv4.
+    pub fn leave_multicast_v4(&self, addr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.socket.leave_multicast_v4(addr, interface)
+    }
+
     pub fn set_multicast_if_v4(&self, interface: &Ipv4Addr) -> io::Result<()> {
         self.socket.set_multicast_if_v4(interface)
     }
@@ -102,6 +107,11 @@ impl PktInfoUdpSocket {
 
     pub fn join_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.socket.join_multicast_v6(addr, interface)
+    }
+
+    /// Drop membership in a multicast group for IPv6.
+    pub fn leave_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
+        self.socket.leave_multicast_v6(addr, interface)
     }
 
     pub fn set_multicast_if_v6(&self, interface: u32) -> io::Result<()> {
@@ -222,5 +232,12 @@ impl PktInfoUdpSocket {
             )),
             Some(info) => Ok((bytes_recv as _, info)),
         }
+    }
+
+    /// Creates a new independently owned std UdpSocket from this PktInfoUdpSocket.
+    ///
+    /// This is useful to mix and match functionality from this crate with stdlib or other crates.
+    pub fn try_clone_std(&self) -> io::Result<std::net::UdpSocket> {
+        Ok(self.socket.try_clone()?.into())
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -136,6 +136,11 @@ impl PktInfoUdpSocket {
         self.socket.join_multicast_v4(addr, interface)
     }
 
+    /// Drop membership in a multicast group for IPv4.
+    pub fn leave_multicast_v4(&self, addr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.socket.leave_multicast_v4(addr, interface)
+    }
+
     pub fn set_multicast_if_v4(&self, interface: &Ipv4Addr) -> io::Result<()> {
         self.socket.set_multicast_if_v4(interface)
     }
@@ -150,6 +155,11 @@ impl PktInfoUdpSocket {
 
     pub fn join_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.socket.join_multicast_v6(addr, interface)
+    }
+
+    /// Drop membership in a multicast group for IPv6.
+    pub fn leave_multicast_v6(&self, addr: &Ipv6Addr, interface: u32) -> io::Result<()> {
+        self.socket.leave_multicast_v6(addr, interface)
     }
 
     pub fn set_multicast_if_v6(&self, interface: u32) -> io::Result<()> {
@@ -267,5 +277,12 @@ impl PktInfoUdpSocket {
             )),
             Some(info) => Ok((read_bytes as usize, info)),
         }
+    }
+
+    /// Creates a new independently owned std UdpSocket from this PktInfoUdpSocket.
+    ///
+    /// This is useful to mix and match functionality from this crate with stdlib or other crates.
+    pub fn try_clone_std(&self) -> io::Result<std::net::UdpSocket> {
+        Ok(self.socket.try_clone()?.into())
     }
 }

--- a/tests/ipv4_test.rs
+++ b/tests/ipv4_test.rs
@@ -57,11 +57,6 @@ fn ipv4_test() -> io::Result<()> {
         let data = "Hello";
         output_socket.send_to(data.as_bytes(), &local_addr)?;
     }
-    {
-        let output_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
-        let data = "Hello";
-        output_socket.send_to(data.as_bytes(), &local_addr)?;
-    }
 
     let (_, info) = socket.recv(&mut buf)?;
     println!(

--- a/tests/ipv4_test.rs
+++ b/tests/ipv4_test.rs
@@ -47,6 +47,16 @@ fn ipv4_test() -> io::Result<()> {
     socket.set_multicast_ttl_v4(255)?;
     socket.bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port).into())?;
 
+    let std_udp_socket = socket.try_clone_std()?;
+    assert!(
+        std_udp_socket.local_addr()? == SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+    );
+
+    {
+        let output_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+        let data = "Hello";
+        output_socket.send_to(data.as_bytes(), &local_addr)?;
+    }
     {
         let output_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
         let data = "Hello";

--- a/tests/ipv6_test.rs
+++ b/tests/ipv6_test.rs
@@ -45,6 +45,12 @@ fn ipv6_test() -> io::Result<()> {
     socket.set_multicast_hops_v6(255)?;
     socket.bind(&local_addr)?;
 
+    let std_udp_socket = socket.try_clone_std()?;
+    assert_eq!(
+        std_udp_socket.local_addr()?,
+        local_addr.as_socket().unwrap()
+    );
+
     {
         let output_socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
         let data = "Hello";


### PR DESCRIPTION
Adding three wrapper methods for `PktInfoUdpSocket` to support `mdns-sd` use cases (its [PR](https://github.com/keepsimple1/mdns-sd/pull/373)).

- add PktInfoUdpSocket::try_clone_std: to mix the use with `mio` crate.
- add two methods to drop multicast group membership: to remove interfaces from mdns polling.

